### PR TITLE
Allow to provide FQDN instead of IP address as mqtt server

### DIFF
--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -25,10 +25,13 @@ PubSubClient mqttClient(espClient);
 /********************************** SETUP MQTT QUEUE **********************************/
 void QueueManager::setupMQTTQueue(void (*callback)(char*, byte*, unsigned int)) {
 
-  mqttClient.setServer(IPAddress(helper.getValue(mqttIP,'.',0).toInt(),
-                                 helper.getValue(mqttIP,'.',1).toInt(),
-                                 helper.getValue(mqttIP,'.',2).toInt(),
-                                 helper.getValue(mqttIP,'.',3).toInt()), mqttPort.toInt());
+  IPAddress ipAddress;
+  // Extract ip address from string and if it fails assume this might be FQDN
+  if (ipAddress.fromString(mqttIP)) {
+    mqttClient.setServer(ipAddress, mqttPort.toInt());
+  } else {
+    mqttClient.setServer(mqttIP, mqttPort.toInt());
+  }
   mqttClient.setCallback(callback);
   mqttClient.setBufferSize(MQTT_MAX_PACKET_SIZE);
   mqttClient.setKeepAlive(MQTT_KEEP_ALIVE);


### PR DESCRIPTION
Currently when you provide FQDN under mqtt server on bootstrapper page, there is no validation. This change is to allow using the value further, when setting the mqtt server information (which is hold in `mqttIP`) to be used.

Modification is to use `IPAddress.fromString` to determine if the mqtt is IP address and if not then to use `mqttIP` as string.

I was not able to test or build the change (I have no idea how to set up the environment), but hopefully it can address https://github.com/ratgdo/mqtt-ratgdo/issues/98